### PR TITLE
Install meshes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,3 +77,8 @@ FILE(GLOB_RECURSE all_files ${CMAKE_SOURCE_DIR}/*)
 add_custom_target(all_files_${PROJECT_NAME} SOURCES ${all_files})
 
 
+# Install meshes
+install(DIRECTORY
+  meshes
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)


### PR DESCRIPTION
Install meshes so that they are accessible from the `install` space as well. Currently they are only accessible from the `devel` space.